### PR TITLE
Update command to install kubectl provider

### DIFF
--- a/thornodes/kubernetes/setup.md
+++ b/thornodes/kubernetes/setup.md
@@ -124,10 +124,16 @@ Run the following:
 
 ```text
 mkdir -p ~/.terraform.d/plugins && \
-    curl -Ls https://api.github.com/repos/gavinbunney/terraform-provider-kubectl/releases/latest \
-    | jq -r ".assets[] | select(.browser_download_url | contains(\"$(uname -s | tr A-Z a-z)\")) | select(.browser_download_url | contains(\"amd64\")) | .browser_download_url" \
-    | xargs -n 1 curl -Lo ~/.terraform.d/plugins/terraform-provider-kubectl && \
-    chmod +x ~/.terraform.d/plugins/terraform-provider-kubectl
+      curl -Ls https://api.github.com/repos/gavinbunney/terraform-provider-kubectl/releases/tags/v1.6.2 \
+      | jq -r ".assets[] | select(.browser_download_url | contains(\"$(uname -s | tr A-Z a-z)\")) | select(.browser_download_url | contains(\"amd64\")) | .browser_download_url" \
+      | xargs -n 1 curl -Lo ~/.terraform.d/plugins/terraform-provider-kubectl.zip && \
+      pushd ~/.terraform.d/plugins/ && \
+      unzip ~/.terraform.d/plugins/terraform-provider-kubectl.zip -d terraform-provider-kubectl-tmp && \
+      mv terraform-provider-kubectl-tmp/terraform-provider-kubectl* . && \
+      chmod +x terraform-provider-kubectl* && \
+      rm -rf terraform-provider-kubectl-tmp && \
+      rm -rf terraform-provider-kubectl.zip && \
+      popd
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
Due to a change in package formats for newer versions of kubectl, this command no longer works for a fresh cluster install. I have provided the updated command with the version tagged to v1.6.2 which is what the cluster-launcher terraform provider calls for.