### PR TITLE
fix: increment midgard api version

### DIFF
--- a/developers/connecting-to-thorchain.md
+++ b/developers/connecting-to-thorchain.md
@@ -35,9 +35,9 @@ http://&lt;host&gt;:8080/v2/doc
   
 **Official**
 
-[https://midgard.thorchain.info/v1/doc](https://midgard.thorchain.info/v1/doc)
+[https://midgard.thorchain.info/v2/doc](https://midgard.thorchain.info/v1/doc)
 
-[https://testnet.midgard.thorchain.info/v1/doc](https://testnet.midgard.thorchain.info/v1/doc)
+[https://testnet.midgard.thorchain.info/v2/doc](https://testnet.midgard.thorchain.info/v1/doc)
 {% endtab %}
 
 {% tab title="THORNODE" %}


### PR DESCRIPTION
Fixing Midgard links on connecting to Thorchain page. Seems testnet is also on v2, though it returns 502 bad gateway.