### PR TITLE
VirtualMultSynths update (since disabled to prevent front-running)

### DIFF
--- a/thorchain-finance/continuous-liquidity-pools.md
+++ b/thorchain-finance/continuous-liquidity-pools.md
@@ -143,12 +143,12 @@ If `a = b = 2` then the pool behaves as if the depth is twice as deep, the slip 
 If `a = 2, b = 1` then the `Y` asset will behave as though it is twice as deep as the `X` asset, or, that the pool is no longer 1:1 bonded. Instead the pool can be said to have 67:33 balance, where the liquidity providers are twice as exposed to one asset over the other.
 
 {% hint style="info" %}
-Virtual Depths have been added to all Synth Swaps - using a multiplier of 2. This means that Synth Swaps create 50% less slip and users pay 50% less fees. The multiplier is specified on `/constants` as:
+Virtual Depths were initially applied to Synth Swaps using a multiplier of 2. It was intended that Synth Swaps would create 50% less slip and users pay 50% less fees. However, this was disabled after discovering that this would allow front-running.  The multiplier is specified on `/constants` as:
 
 ```
 "VirtualMultSynths": 2,
 ```
-{% endhint %}
+but currently overridden by a Mimir value of 1.{% endhint %}
 
 ## Calculating Pool Ownership
 

--- a/thorchain-finance/synthetic-asset-model.md
+++ b/thorchain-finance/synthetic-asset-model.md
@@ -13,7 +13,7 @@ THORChain synthetic assets are primitives for both higher-order financial featur
 THORChain synthetics are unique in that they are 50% backed by their own asset, with the other 50% backing being provided by RUNE. This is achieved by using pool ownership to collateralise the synth, which ensures always-on liquidity and pricing.
 
 {% hint style="info" %}
-[Virtual Depths](continuous-liquidity-pools.md#virtual-depths) have been added to all Synth Swaps (Minting and Redeeming). [VirtualMultSynths](../network/constants-and-mimir.md#synths) multiplies the pool depth (R and A) before the swap is calculated. This leads to 50% less slip and users paying 50% less fees.
+[Virtual Depths](continuous-liquidity-pools.md#virtual-depths) were initially applied to Synth Swaps (Minting and Redeeming). [VirtualMultSynths](../network/constants-and-mimir.md#synths) multiplies the pool depth (R and A) before the swap is calculated. This was intended to to implement less slip and thus users paying less fees, but was disabled (VirtualMultSynths set to 1) after it was discovered that this would allow front-running.
 {% endhint %}
 
 ### Minting


### PR DESCRIPTION
VirtualMultSynths were set to 1 through Mimir (2 in overridden Constants) to disable virtual depths after the discovery that they allow front-running.