### PR TITLE
docs: correct outbound fee multiplier from 2.5x to 3x in FAQ

### DIFF
--- a/frequently-asked-questions/README.md
+++ b/frequently-asked-questions/README.md
@@ -58,7 +58,7 @@ The outbound fees that THORChain levies is 1.5x t0 3x the “fast” fee recomme
 - See [ADR 008: Implement a Dynamic Outbound Fee Multiplier](https://dev.thorchain.org/architecture/adr-008-implement-dynamic-outbound-fee-multiplier.html)
 - See [Technical Deep Dive](../technical-deep-dive/).
 
-The outbound fees that THORChain levies could be up to 2.5x the “fast” fee recommended for the respective blockchain.
+The outbound fees that THORChain levies could be up to 3x the "fast" fee recommended for the respective blockchain.
 
 - See [Technical Deep Dive](../technical-deep-dive/).
 - Standard Fee [inbound address](https://thornode.ninerealms.com/thorchain/inbound_addresses) endpoint.


### PR DESCRIPTION
## Summary
Corrects the outbound fee multiplier value in the FAQ from "up to 2.5x" to "up to 3x".

## Source of Truth
- **File:** `thornode/constants/constants_v1.go`
- **Line:** 103
- **Commit:** 83dc71a3d

The `MaxOutboundFeeMultiplierBasisPoints` constant is set to 30,000 (3x), not 25,000 (2.5x).

## Changes
- Updated FAQ to correctly state "up to 3x" instead of "up to 2.5x"

## Test Plan
- [x] Verified against thornode source code
- [x] Markdown renders correctly