### PR TITLE
docs: correct OFM range to reference Mimir parameters

### DIFF
--- a/technical-deep-dive/fees.md
+++ b/technical-deep-dive/fees.md
@@ -53,7 +53,7 @@ Interfaces can include an optional affiliate fee (in basis points) that’s coll
 To deliver your final asset, THORChain pays gas on the destination chain and charges an Outbound Fee from your swap output. This fee:
 
 - Covers actual L1 gas and protocol overhead.
-- Uses a dynamic Outbound Fee Multiplier (OFM) that moves between ~1× and 3× based on network and protocol factors.
+- Uses a dynamic Outbound Fee Multiplier (OFM) that moves between [`MinOutboundFeeMultiplierBasisPoints`](https://thornode.ninerealms.com/thorchain/mimir) (1%) and [`MaxOutboundFeeMultiplierBasisPoints`](https://thornode.ninerealms.com/thorchain/mimir) (300%) based on network and protocol factors.
 - Is published via THORNode endpoints so integrators can budget precisely.
 
 For implementation details, see the [Outbound Fee dev docs](https://dev.thorchain.org/concepts/fees.html#4-outbound-fee).


### PR DESCRIPTION
## Summary
Corrects the Outbound Fee Multiplier range and adds references to the Mimir parameters.

## Issue
The documentation stated the OFM moves between "~1× and 3×" but the actual live Mimir values are:
- `MinOutboundFeeMultiplierBasisPoints`: 100 (1%)
- `MaxOutboundFeeMultiplierBasisPoints`: 30000 (300%)

## Source of Truth
- **Live Mimir:** https://thornode.ninerealms.com/thorchain/mimir

## Changes
- Updated fees.md to show actual range (1% to 300%)
- Added links to Mimir parameters so values stay current

## Test Plan
- [x] Verified against live Mimir values
- [x] Markdown renders correctly