### PR TITLE
docs: correct synth cap constant name to MaxSynthPerPoolDepth

### DIFF
--- a/thorchain-finance/synthetic-asset-model.md
+++ b/thorchain-finance/synthetic-asset-model.md
@@ -104,7 +104,7 @@ The dynamic synth unit accounting is to ensure that gain or loss caused by price
 
 Due to synths, Liquidity Providers are taking a leveraged position on the RUNE asset today. This can help them earn more rewards if RUNE outperforms the asset, but can also go the other way. The higher the percentage of synths that exist on the network relative to pool depth, the higher the leveraged position Liquidity Providers are taking.
 
-Due to this, the minting of synths is capped to an upper limit of the total pool depth to protect Liquidity Providers and the network. The [Mimir](../technical-deep-dive/governance.md#mimir) setting `MaxSynthPerAssetDepth` setting controls the cap which is the asset depth percentage.
+Due to this, the minting of synths is capped to an upper limit of the total pool depth to protect Liquidity Providers and the network. The [Mimir](../technical-deep-dive/governance.md#mimir) setting `MaxSynthPerPoolDepth` controls the cap which is the asset depth percentage.
 
 ### Protocol Owned Liquidity (POL)
 


### PR DESCRIPTION
## Summary
Corrects the synth minting cap constant name from `MaxSynthPerAssetDepth` to `MaxSynthPerPoolDepth`.

## Source of Truth
- **File:** `thornode/constants/constant_values.go`
- **Line:** 67
- **Commit:** 83dc71a3d

The constant is named `MaxSynthPerPoolDepth`, not `MaxSynthPerAssetDepth`.

## Changes
- Updated synthetic-asset-model.md to use the correct constant name

## Test Plan
- [x] Verified against thornode source code
- [x] Markdown renders correctly