### PR TITLE
docs: correct TNS constant name and add missing AVAX chain

### DIFF
--- a/technical-deep-dive/thorchain-name-service.md
+++ b/technical-deep-dive/thorchain-name-service.md
@@ -57,7 +57,7 @@ Example from [https://midgard.ninerealms.com/v2/thorname/lookup/td](https://midg
 }
 ```
 
-Currently, there are eleven (11) native L1 chains available on THORChain: Bitcoin, Ethereum, Litecoin, Binance Smart Chain, Bitcoin Cash, Doge, Cosmos, Base, TRON and XRP. THORNames are limited to 30 characters, including `^[a-zA-Z0-9+_-]+$`.
+Currently, there are eleven (11) native L1 chains available on THORChain: Bitcoin, Ethereum, Litecoin, Binance Smart Chain, Bitcoin Cash, Doge, Cosmos, Avalanche, Base, TRON and XRP. THORNames are limited to 30 characters, including `^[a-zA-Z0-9+_-]+$`.
 
 ### Query a THORName
 
@@ -85,7 +85,7 @@ There is a one-time registration fee of around 10 RUNE, with a 20 `tor` block fe
 
 - `TNSRegisterFee`: 10 RUNE
 - `TNSFeeOnSale`: 1000 Basis Points
-- `TNSBlockFee`: 20 tor per block (roughly 1 RUNE per year)
+- `TNSFeePerBlock`: 20 tor per block (roughly 1 RUNE per year)
 
 Example: a 20 Rune registration registers the THORName for 10 years. (10 RUNE Registration Fee + 1 RUNE every year).
 


### PR DESCRIPTION
## Summary
Two fixes to the THORChain Name Service documentation:

1. **Constant name fix**: Changed `TNSBlockFee` to `TNSFeePerBlock` (the correct constant name)
2. **Chain list fix**: Added missing Avalanche (AVAX) - the doc said "eleven (11)" chains but only listed 10

## Source of Truth
- **Constant name:** `thornode/constants/constants_v1.go:L83`
- **Chain list:** Verified against live mainnet: https://thornode.ninerealms.com/thorchain/inbound_addresses
- **Commit:** 83dc71a3d

## Changes
- Fixed constant name from `TNSBlockFee` to `TNSFeePerBlock`
- Added Avalanche to the chain list to match actual count of 11 chains

## Test Plan
- [x] Verified constant name against thornode source code
- [x] Verified chain list against live mainnet inbound_addresses endpoint
- [x] Markdown renders correctly