### PR TITLE
docs: update outbound throttling to reference Mimir parameters

### DIFF
--- a/technical-deep-dive/security.md
+++ b/technical-deep-dive/security.md
@@ -17,7 +17,7 @@ See more full details [here](https://dev.thorchain.org/bifrost/how-bifrost-works
 To prevent large amounts of funds from leaving the network in an instant, large outbound transactions are throttled from immediately leaving the network. Each block has an outbound value limit (currently 1000 RUNE worth) and each outbound transaction has a maximum time limit that it can be processed. This has three effects:
 
 - Each outbound transaction to compete for the next outbound block, else, it will be processed in the following block, effectively throttling the total outbound capacity of the network. This is independent of [conf-counting](https://docs.thorchain.org/chain-clients/overview#confirmation-counting).
-- Large outbounds to spread across multiple blocks, up to 720 blocks (approx one hour).
+- Large outbounds to spread across multiple blocks, up to 17,280 blocks (approx one day).
 - Ensures one large outbound request of $1,000,000 is handled the same as one million $1 outbound requests.
 
 This feature is controlled by several [Mimir](constants-and-mimir.md#outbound-transactions) values that can be changed by Node Operators as required. [Relevant PR](https://gitlab.com/thorchain/thornode/-/merge_requests/1844).

--- a/technical-deep-dive/security.md
+++ b/technical-deep-dive/security.md
@@ -14,10 +14,10 @@ See more full details [here](https://dev.thorchain.org/bifrost/how-bifrost-works
 
 ## Outbound Transaction Throttling
 
-To prevent large amounts of funds from leaving the network in an instant, large outbound transactions are throttled from immediately leaving the network. Each block has an outbound value limit (currently 1000 RUNE worth) and each outbound transaction has a maximum time limit that it can be processed. This has three effects:
+To prevent large amounts of funds from leaving the network in an instant, large outbound transactions are throttled from immediately leaving the network. Each block has an outbound value limit controlled by `MinTxOutVolumeThreshold` and each outbound transaction has a maximum time limit that it can be processed. This has three effects:
 
 - Each outbound transaction to compete for the next outbound block, else, it will be processed in the following block, effectively throttling the total outbound capacity of the network. This is independent of [conf-counting](https://docs.thorchain.org/chain-clients/overview#confirmation-counting).
-- Large outbounds to spread across multiple blocks, up to 17,280 blocks (approx one day).
+- Large outbounds to spread across multiple blocks. The initial delay is capped by `MaxTxOutOffset`, then the network searches for an available slot up to `TxOutDelayMax` if blocks are full.
 - Ensures one large outbound request of $1,000,000 is handled the same as one million $1 outbound requests.
 
 This feature is controlled by several [Mimir](constants-and-mimir.md#outbound-transactions) values that can be changed by Node Operators as required. [Relevant PR](https://gitlab.com/thorchain/thornode/-/merge_requests/1844).


### PR DESCRIPTION
## Summary
Updates the outbound transaction throttling documentation to reference Mimir parameter names instead of hardcoded values that have changed.

## Issues Fixed
1. **Per-block limit**: Doc said "currently 1000 RUNE worth" but `MinTxOutVolumeThreshold` is now 20,000 RUNE
2. **Delay description**: Doc said "720 blocks (approx one hour)" which was incorrect. The delay mechanism uses:
   - `MaxTxOutOffset`: Caps initial calculated delay (currently 200 blocks, ~20 mins)
   - `TxOutDelayMax`: Search limit for finding available slots if blocks are full

## Source of Truth
- **Code:** `thornode/x/thorchain/manager_txout_current.go:L1082-1176`
- **Live Mimir:** https://thornode.ninerealms.com/thorchain/mimir
- **Commit:** 83dc71a3d

## Changes
- Replaced hardcoded "1000 RUNE worth" with reference to `MinTxOutVolumeThreshold`
- Replaced incorrect "720 blocks" with accurate description of `MaxTxOutOffset` and `TxOutDelayMax` interaction

## Test Plan
- [x] Verified against thornode source code
- [x] Verified against live Mimir values
- [x] Markdown renders correctly