### PR TITLE
docs: remove hardcoded NUMBEROFNEWNODESPERCHURN value

### DIFF
--- a/thornodes/leaving.md
+++ b/thornodes/leaving.md
@@ -18,7 +18,7 @@ Note: Just less than 1/3 of the active network can be churned out in a single ch
 
 Incoming:
 
-1. The node(s) with the highest bond (2 or [`NUMBEROFNEWNODESPERCHURN`](https://thornode.ninerealms.com/thorchain/mimir)).
+1. The node(s) with the highest bond ([`NUMBEROFNEWNODESPERCHURN`](https://thornode.ninerealms.com/thorchain/mimir) nodes).
 
 Churned out nodes will be put in standby, but their bond will not automatically be returned. They will be credited any earned rewards in their last session. If they do nothing, but keep their cluster online and up-to-date with the latest THORNode version, they will be eventually churn back in.
 


### PR DESCRIPTION
## Summary
Removes the hardcoded value "2" for NUMBEROFNEWNODESPERCHURN since the live Mimir value is currently 4.

## Issue
The documentation stated "(2 or NUMBEROFNEWNODESPERCHURN)" but the actual Mimir value is 4. Rather than updating to a new hardcoded value, removed the number entirely and just reference the Mimir key.

## Source of Truth
- **Live Mimir:** https://thornode.ninerealms.com/thorchain/mimir
- **Current value:** NUMBEROFNEWNODESPERCHURN = 4

## Changes
- Changed "(2 or `NUMBEROFNEWNODESPERCHURN`)" to "(`NUMBEROFNEWNODESPERCHURN` nodes)"

## Test Plan
- [x] Verified against live Mimir values
- [x] Markdown renders correctly