### PR TITLE
Replace decommissioned ninerealms.com endpoints

### DIFF
--- a/archived/lending-faq.md
+++ b/archived/lending-faq.md
@@ -15,7 +15,7 @@ Lending allowed users to deposit native collateral, and then create a debt at a 
 - [More information](lending.md)
 - [Launch Article](https://medium.com/thorchain/lending-on-thorchain-646bbf2e6e1b)
 - [Explanation Video](https://youtu.be/AaqHG00RJks)
-- [Health Dashboard](https://dashboards.ninerealms.com/#lending)
+- [Health Dashboard](https://dashboards.thorchain.org/#lending)
 
 ### What was TOR?
 

--- a/archived/lending.md
+++ b/archived/lending.md
@@ -96,7 +96,7 @@ Collateral was not returned until the loan was fully repaid. The user always had
 
 ### Dashboard
 
-* [Lending Health Dashboard by NineRealms](https://dashboards.ninerealms.com/#lending)
+* [Lending Health Dashboard](https://dashboards.thorchain.org/#lending)
 * [Lending Dashboard by banbannard](https://flipsidecrypto.xyz/banbannard/thorchain-lending-fOAKej)
 
 ### Design Documents

--- a/ecosystem.md
+++ b/ecosystem.md
@@ -112,7 +112,7 @@ Below is a list of active THORChain community projects. If you would like to be 
 
 [**THORCharts**](https://thorcharts.org/) - Key stats and figures related to core THORChain operations
 
-[**Nine Realms Dashboard**](https://dashboards.thorchain.org/)
+[**THORChain Dashboard**](https://dashboards.thorchain.org/)
 
 [**THORYield**](https://thoryield.com/) - View your added liquidity on THORChain
 

--- a/ecosystem.md
+++ b/ecosystem.md
@@ -18,7 +18,7 @@ All the following are community-run resources. There are no "official" channels.
 
 **Security:** [**Layers of Security**](https://medium.com/thorchain/thorchains-layers-of-security-e308d537acf1) **|** [**Hardening the Protocol**](https://medium.com/thorchain/hardening-the-thorchain-protocol-f80164de7685)**|** [**Halt Controls**](https://dev.thorchain.org/concepts/network-halts.html)
 
-**Block Explorers**: [**RuneScan**](https://runescan.io) **|** [**THORChain.net**](https://thorchain.net/#/txs) **|** [**THORChain Tx Tracker**](https://track.ninerealms.com/) **|** [**xScanner**](https://www.xscanner.org/)
+**Block Explorers**: [**RuneScan**](https://runescan.io) **|** [**THORChain.net**](https://thorchain.net/#/txs) **|** [**THORChain Tx Tracker**](https://track.thorchain.org/) **|** [**xScanner**](https://www.xscanner.org/)
 
 **Community:** [**Community Discord**](https://discord.com/invite/c4EhDZdFMA) **|** [**Community Telegram**](https://t.me/thorchain_org) **|** [**X**](https://x.com/thorchain)&#x20;
 
@@ -112,7 +112,7 @@ Below is a list of active THORChain community projects. If you would like to be 
 
 [**THORCharts**](https://thorcharts.org/) - Key stats and figures related to core THORChain operations
 
-[**Nine Realms Dashboard**](https://dashboards.ninerealms.com/)
+[**Nine Realms Dashboard**](https://dashboards.thorchain.org/)
 
 [**THORYield**](https://thoryield.com/) - View your added liquidity on THORChain
 
@@ -132,13 +132,13 @@ Below is a list of active THORChain community projects. If you would like to be 
 
 [**THORmon**](https://thorchain.network/)- Detailed THORNode Dashboard
 
-[**Constants**](https://thornode.ninerealms.com/thorchain/constants)- Current THORChain Constants
+[**Constants**](https://gateway.liquify.com/chain/thorchain_api/thorchain/constants)- Current THORChain Constants
 
-[**Mimir**](https://thornode.ninerealms.com/thorchain/mimir) - Overrides for Constants
+[**Mimir**](https://gateway.liquify.com/chain/thorchain_api/thorchain/mimir) - Overrides for Constants
 
-[**Midgard Docs**](https://midgard.ninerealms.com/v2/doc) - Documentation for Midgard API to query THORChain.
+[**Midgard Docs**](https://gateway.liquify.com/chain/thorchain_midgard/v2/doc) - Documentation for Midgard API to query THORChain.
 
-[**Thornode Docs**](https://thornode.ninerealms.com/thorchain/doc/) - Documentation for Thornode API to query Thornode.
+[**Thornode Docs**](https://gateway.liquify.com/chain/thorchain_api/thorchain/doc/) - Documentation for Thornode API to query Thornode.
 
 [**RuneScan Explorer**](https://runescan.io)- THORChain Block Explorer
 

--- a/frequently-asked-questions/README.md
+++ b/frequently-asked-questions/README.md
@@ -28,7 +28,7 @@ Directly on THORChain by swapping any supported asset for RUNE or exchanges like
 
 ### **What is the circulating supply of RUNE?**
 
-Approx. 330M with a max of 500M. Full details at [https://ops.ninerealms.com/network](https://ops.ninerealms.com/network) or [hhttps://runescan.io/addresses](https://runescan.io/addresses/) for a breakdown of the RUNE supply.
+Approx. 330M with a max of 500M. See [https://runescan.io/addresses](https://runescan.io/addresses/) for a breakdown of the RUNE supply.
 
 ### **What is the inflation rate of RUNE?**
 
@@ -54,14 +54,14 @@ Yes, there is a fee for every on-chain withdrawal from THORChain, whether it is 
 
 The outbound fees that THORChain levies is 1.5x t0 3x the “fast” fee recommended for the respective blockchain, depending on network load.
 
-- See The `outbound_fee_multiplier` pararamter in the [network endpoint](https://thornode.ninerealms.com/thorchain/network)
+- See the `outbound_fee_multiplier` parameter in the [network endpoint](https://gateway.liquify.com/chain/thorchain_api/thorchain/network)
 - See [ADR 008: Implement a Dynamic Outbound Fee Multiplier](https://dev.thorchain.org/architecture/adr-008-implement-dynamic-outbound-fee-multiplier.html)
 - See [Technical Deep Dive](../technical-deep-dive/).
 
 The outbound fees that THORChain levies could be up to 2.5x the “fast” fee recommended for the respective blockchain.
 
 - See [Technical Deep Dive](../technical-deep-dive/).
-- Standard Fee [inbound address](https://thornode.ninerealms.com/thorchain/inbound_addresses) endpoint.
+- Standard Fee [inbound address](https://gateway.liquify.com/chain/thorchain_api/thorchain/inbound_addresses) endpoint.
 - [Watch Fees and Wait Times Explained](https://www.youtube.com/watch?v=XAdaEXO-Ofg) video.
 
 #### Is there a place where I can see the THORChain Ecosystem?
@@ -72,7 +72,7 @@ Yes, the [website](https://thorchain.org/ecosystem) or the [Ecosystem](../ecosys
 
 **How fast is THORChain?**
 
-Transactions Per Second (TPS), can go up to 5000 TPS, but are rarely seen. The highest number of swaps in one day was 100k swaps. Current transaction data can be seen at [https://runescan.io/](https://runescan.io/) and [https://midgard.ninerealms.com/v2/stats](https://midgard.ninerealms.com/v2/stats)
+Transactions Per Second (TPS), can go up to 5000 TPS, but are rarely seen. The highest number of swaps in one day was 100k swaps. Current transaction data can be seen at [https://runescan.io/](https://runescan.io/) and [https://gateway.liquify.com/chain/thorchain_midgard/v2/stats](https://gateway.liquify.com/chain/thorchain_midgard/v2/stats)
 
 #### Why use BFT Tendermint?
 
@@ -135,7 +135,7 @@ There is no contract address for RUNE, as it is the native asset on its own bloc
 
 Make sure you have a sufficient amount of RUNE to process transactions. Also be sure to check if the liquidity caps are full. If so, you will not be able to add liquidity at that time. If you see errors like “No UTXOs to send” or “Need to wait for more UTXO confirmation”; likely you are trying to spend UTXO assets (BTC, LTC, BCH) that you have just transferred into your wallet. Please wait for more blockchain confirmations, and try again later!
 
-➜ [Check Stuck transactions](https://track.ninerealms.com/)
+➜ [Check Stuck transactions](https://track.thorchain.org/)
 
 ### THORYield is displaying incorrect information?
 

--- a/frequently-asked-questions/README.md
+++ b/frequently-asked-questions/README.md
@@ -28,7 +28,7 @@ Directly on THORChain by swapping any supported asset for RUNE or exchanges like
 
 ### **What is the circulating supply of RUNE?**
 
-Approx. 330M with a max of 500M. See [https://runescan.io/addresses](https://runescan.io/addresses/) for a breakdown of the RUNE supply.
+Approx. 360M. See [https://runescan.io/addresses](https://runescan.io/addresses/) for a breakdown of the RUNE supply.
 
 ### **What is the inflation rate of RUNE?**
 

--- a/technical-deep-dive/governance.md
+++ b/technical-deep-dive/governance.md
@@ -45,8 +45,8 @@ THORChain operates with a set of constants that define fees, limits and security
 
 Live values:
 
-- [Network Constants](https://thornode.ninerealms.com/thorchain/constants)
-- [Mimir Settings](https://thornode.ninerealms.com/thorchain/mimir)
+- [Network Constants](https://gateway.liquify.com/chain/thorchain_api/thorchain/constants)
+- [Mimir Settings](https://gateway.liquify.com/chain/thorchain_api/thorchain/mimir)
 
 See [Constants and Mimir](https://dev.thorchain.org/mimir.html) within the developer documentation for a description of each one.
 

--- a/technical-deep-dive/thorchain-name-service.md
+++ b/technical-deep-dive/thorchain-name-service.md
@@ -14,7 +14,7 @@ Users use a special memo and a THORChain `MsgDeposit` transaction to register th
 
 A THORChain address can be assigned one (1) THORName to manage the other addresses associated. For example: the THORName chris can receive $BTC to the chris.btc address, chris.eth to receive $ETH and so forth. Wallet providers will easily be able to integrate to resolve cross-chain addresses for a user.
 
-Example from [https://midgard.ninerealms.com/v2/thorname/lookup/td](https://midgard.ninerealms.com/v2/thorname/lookup/td)
+Example from [https://gateway.liquify.com/chain/thorchain_midgard/v2/thorname/lookup/td](https://gateway.liquify.com/chain/thorchain_midgard/v2/thorname/lookup/td)
 
 ```json
 {
@@ -64,19 +64,19 @@ Currently, there are eleven (11) native L1 chains available on THORChain: Bitcoi
 A THORName can be queried by going to `/thorname/{thorname}`
 
 {% hint style="info" %}
-[https://midgard.ninerealms.com/v2/thorname/lookup/orion](https://midgard.ninerealms.com/v2/thorname/lookup/orion)
+[https://gateway.liquify.com/chain/thorchain_midgard/v2/thorname/lookup/orion](https://gateway.liquify.com/chain/thorchain_midgard/v2/thorname/lookup/orion)
 {% endhint %}
 
 A THORName can be checked using `/thorname/lookup/{thorname}`
 
 {% hint style="info" %}
-[https://midgard.ninerealms.com/v2/thorname/lookup/orion](https://midgard.ninerealms.com/v2/thorname/lookup/orion)
+[https://gateway.liquify.com/chain/thorchain_midgard/v2/thorname/lookup/orion](https://gateway.liquify.com/chain/thorchain_midgard/v2/thorname/lookup/orion)
 {% endhint %}
 
 While there is no reverse on-chain reverse lookup, a reverse lookup is possible within THORChain via using a given THORName `/thorname/lookup/{address}.`
 
 {% hint style="info" %}
-Example using a THOR address: [https://midgard.ninerealms.com/v2/thorname/rlookup/thor15r77zzt7n6kyydw7ajkefdrrv6n0dpplvm83pd](https://midgard.ninerealms.com/v2/thorname/rlookup/thor15r77zzt7n6kyydw7ajkefdrrv6n0dpplvm83pd)
+Example using a THOR address: [https://gateway.liquify.com/chain/thorchain_midgard/v2/thorname/rlookup/thor15r77zzt7n6kyydw7ajkefdrrv6n0dpplvm83pd](https://gateway.liquify.com/chain/thorchain_midgard/v2/thorname/rlookup/thor15r77zzt7n6kyydw7ajkefdrrv6n0dpplvm83pd)
 {% endhint %}
 
 ## Fees

--- a/technology/midgard.md
+++ b/technology/midgard.md
@@ -8,8 +8,8 @@ Midgard is a layer 2 REST API that provides front-end consumers with semi real-t
 
 Midgard is heavily used in dashboards and transaction scanners like [Thorchain.net](https://thorchain.net/), [Thorchain.network](https://thorchain.network/) and [Runescan.io](https://runescan.io/). You find a full overview of the REST API endpoints on:
 
-- [https://thornode.ninerealms.com/thorchain/doc](https://thornode.ninerealms.com/thorchain/doc)
-- [https://midgard.ninerealms.com/v2/doc](https://midgard.ninerealms.com/v2/doc)
+- [https://gateway.liquify.com/chain/thorchain_api/thorchain/doc](https://gateway.liquify.com/chain/thorchain_api/thorchain/doc)
+- [https://gateway.liquify.com/chain/thorchain_midgard/v2/doc](https://gateway.liquify.com/chain/thorchain_midgard/v2/doc)
 
 For more information see [Gitlab repo](https://gitlab.com/thorchain/midgard).
 

--- a/thorchain-finance/tor.md
+++ b/thorchain-finance/tor.md
@@ -24,7 +24,7 @@ The depth of the TOR pool is calculated as the sum of all TOR pools. However, it
 
 ### TOR Anchor
 
-You can find the addresses for various stablecoins on specific networks (TORANCHOR) that make up TOR pools on [Mimir](https://thornode.ninerealms.com/thorchain/mimir):
+You can find the addresses for various stablecoins on specific networks (TORANCHOR) that make up TOR pools on [Mimir](https://gateway.liquify.com/chain/thorchain_api/thorchain/mimir):
 
 ```json
 "TORANCHOR-AVAX-USDC-0XB97EF9EF8734C71904D8002F8B6BC66DD9C48A6E": 1,

--- a/thorchain-finance/trade-assets.md
+++ b/thorchain-finance/trade-assets.md
@@ -107,7 +107,7 @@ Withdraw 0.1 BTC from the Trade Account and send to the specified address.
 Balances can be verified using the Owner's THORChain Address via the `trade/account/` endpoint. Example:
 
 ```url
-https://thornode.ninerealms.com/thorchain/trade/account/thor1g6pnmnyeg48yc3lg796plt0uw50qpp7humfggz
+https://gateway.liquify.com/chain/thorchain_api/thorchain/trade/account/thor1g6pnmnyeg48yc3lg796plt0uw50qpp7humfggz
 ```
 
 ### Future Opportunities

--- a/thornodes/deploying.md
+++ b/thornodes/deploying.md
@@ -143,7 +143,7 @@ kubectl logs -f deploy/binance-daemon -n thornode
 {% endhint %}
 
 {% hint style="info" %}
-Get real-world blockheights of external blockchain at [https://thornode.ninerealms.com/thorchain/lastblock](https://thornode.ninerealms.com/thorchain/lastblock) or a block explorer like mempool.space.
+Get real-world blockheights of external blockchain at [https://gateway.liquify.com/chain/thorchain_api/thorchain/lastblock](https://gateway.liquify.com/chain/thorchain_api/thorchain/lastblock) or a block explorer like mempool.space.
 {% endhint %}
 
 ## CHART SUMMARY

--- a/thornodes/fullnode/midgard-docker.md
+++ b/thornodes/fullnode/midgard-docker.md
@@ -31,14 +31,17 @@ mkdir -p /opt/midgard/{config,blockstore}
 
 ### Genesis
 
-Download genesis file
+Download the genesis file.
 
-```sh
-# get genesis.json
-curl https://storage.googleapis.com/public-snapshots-ninerealms/genesis/17562000.json -o /opt/midgard/config/genesis.json
-```
+{% hint style="warning" %}
+Nine Realms infrastructure has been decommissioned. Refer to the upstream [node-launcher documentation](https://gitlab.com/thorchain/devops/node-launcher/-/tree/master/docs) for the current genesis file source.
+{% endhint %}
 
-Add midgard config
+Add midgard config.
+
+{% hint style="warning" %}
+Nine Realms infrastructure has been decommissioned. The `blockstore.remote` field below is left empty — refer to the upstream [Thornode Snapshot Recovery and Storage Management](https://gitlab.com/thorchain/devops/node-launcher/-/blob/master/docs/Thornode-Snapshot-Recovery-and-Storage-Management.md) doc for the current value.
+{% endhint %}
 
 {% code title="/opt/midgard/config/config.json" overflow="wrap" %}
 
@@ -52,8 +55,8 @@ Add midgard config
     "fetch_batch_size": 100,
     "parallelism": 4,
     "read_timeout": "60s",
-    "tendermint_url": "https://rpc.ninerealms.com/websocket",
-    "thornode_url": "https://thornode.ninerealms.com/thorchain",
+    "tendermint_url": "https://gateway.liquify.com/chain/thorchain_rpc/websocket",
+    "thornode_url": "https://gateway.liquify.com/chain/thorchain_api/thorchain",
     "fork_infos": [
       {
         "chain_id": "thorchain-1",
@@ -93,7 +96,7 @@ Add midgard config
   },
   "blockstore": {
     "local": "/blockstore",
-    "remote": "https://snapshots.ninerealms.com/snapshots/midgard-blockstore/"
+    "remote": ""
   }
 }
 ```

--- a/thornodes/fullnode/midgard-linux.md
+++ b/thornodes/fullnode/midgard-linux.md
@@ -135,12 +135,17 @@ As `midgard` user run:
 
 ```sh
 mkdir $HOME/config
-
-# get genesis.json
-curl https://storage.googleapis.com/public-snapshots-ninerealms/genesis/17562000.json -o $HOME/config/genesis.json
 ```
 
-Add midgard config
+{% hint style="warning" %}
+Nine Realms infrastructure has been decommissioned. Refer to the upstream [node-launcher documentation](https://gitlab.com/thorchain/devops/node-launcher/-/tree/master/docs) for the current genesis file source, then place it at `$HOME/config/genesis.json`.
+{% endhint %}
+
+Add midgard config.
+
+{% hint style="warning" %}
+Nine Realms infrastructure has been decommissioned. The `blockstore.remote` field below is left empty — refer to the upstream [Thornode Snapshot Recovery and Storage Management](https://gitlab.com/thorchain/devops/node-launcher/-/blob/master/docs/Thornode-Snapshot-Recovery-and-Storage-Management.md) doc for the current value.
+{% endhint %}
 
 {% code title="/home/midgard/config/midgard.json" overflow="wrap" %}
 
@@ -154,8 +159,8 @@ Add midgard config
     "fetch_batch_size": 100,
     "parallelism": 4,
     "read_timeout": "60s",
-    "tendermint_url": "https://rpc.ninerealms.com/websocket",
-    "thornode_url": "https://thornode.ninerealms.com/thorchain",
+    "tendermint_url": "https://gateway.liquify.com/chain/thorchain_rpc/websocket",
+    "thornode_url": "https://gateway.liquify.com/chain/thorchain_api/thorchain",
     "fork_infos": [
       {
         "chain_id": "thorchain-1",
@@ -195,7 +200,7 @@ Add midgard config
   },
   "blockstore": {
     "local": "./tmp/blockstore",
-    "remote": "https://snapshots.ninerealms.com/snapshots/midgard-blockstore/"
+    "remote": ""
   }
 }
 ```

--- a/thornodes/fullnode/thornode-docker.md
+++ b/thornodes/fullnode/thornode-docker.md
@@ -30,32 +30,19 @@ mkdir -p /opt/thornode/.thornode/config
 
 ### Genesis
 
-For joining the network, the correct genesis file is required
+For joining the network, the correct genesis file is required.
 
-```sh
-curl https://storage.googleapis.com/public-snapshots-ninerealms/genesis/17562000.json -o /opt/thornode/.thornode/config/genesis.json
-```
+{% hint style="warning" %}
+Nine Realms infrastructure has been decommissioned. Refer to the upstream [node-launcher documentation](https://gitlab.com/thorchain/devops/node-launcher/-/tree/master/docs) for the current genesis file source.
+{% endhint %}
 
 ### Sync
 
-The fastest way to join the network is by downloading a current snapshot and sync from it.
+The fastest way to join the network is by downloading a current snapshot and syncing from it.
 
-```sh
-# get latest snapshot
-FILENAME=$(curl -s "https://snapshots.ninerealms.com/snapshots?prefix=thornode" | grep -Eo "thornode/[0-9]+.tar.gz" | sort -n | tail -n 1 | cut -d "/" -f 2)
-
-# download snapshot
-aria2c --split=16 --max-concurrent-downloads=16 --max-connection-per-server=16 --continue --min-split-size=100M -d /opt/thornode/.thornode -o $FILENAME "https://snapshots.ninerealms.com/snapshots/thornode/${FILENAME}"
-
-# ensure no chain data exists
-rm -rf /opt/thornode/.thornode/data/{*.db,snapshot,cs.wal}
-
-# extract snapshot
-pv /opt/thornode/.thornode/$FILENAME | tar -xzf - -C /opt/thornode/.thornode --exclude "*_state.json"
-
-# cleanup snapshot
-rm -rf /opt/thornode/.thornode/$FILENAME
-```
+{% hint style="warning" %}
+Nine Realms infrastructure has been decommissioned. Refer to the upstream [Thornode Snapshot Recovery and Storage Management](https://gitlab.com/thorchain/devops/node-launcher/-/blob/master/docs/Thornode-Snapshot-Recovery-and-Storage-Management.md) doc for the current snapshot source and recovery procedure.
+{% endhint %}
 
 ## Start
 

--- a/thornodes/fullnode/thornode-linux.md
+++ b/thornodes/fullnode/thornode-linux.md
@@ -62,11 +62,9 @@ $HOME/go/bin/thornode init thornode --overwrite --chain-id thorchain-1
 
 Seeds provide a list of active thorchain nodes, which are needed to join the network.
 
-As `thornode` user run:
-
-```sh
-sed -i 's/^seeds = ""/seeds = "c3613862c2608b3e861406ad02146f41cf5124e6@statesync-seed.ninerealms.com:27146,dbd1730bff1e8a21aad93bc6083209904d483185@statesync-seed-2.ninerealms.com:27146"/' $HOME/.thornode/config/config.toml
-```
+{% hint style="warning" %}
+Nine Realms infrastructure has been decommissioned. Refer to the upstream [node-launcher documentation](https://gitlab.com/thorchain/devops/node-launcher/-/tree/master/docs) for the current seed list.
+{% endhint %}
 
 ### Ports
 
@@ -80,36 +78,19 @@ sed -ri 's/:2665([0-9])/:2714\1/g' $HOME/.thornode/config/config.toml
 
 ### Genesis
 
-For joining the network, the correct genesis file is required
+For joining the network, the correct genesis file is required.
 
-As `thornode` user run:
-
-```sh
-curl https://storage.googleapis.com/public-snapshots-ninerealms/genesis/17562000.json -o $HOME/.thornode/config/genesis.json
-```
+{% hint style="warning" %}
+Nine Realms infrastructure has been decommissioned. Refer to the upstream [node-launcher documentation](https://gitlab.com/thorchain/devops/node-launcher/-/tree/master/docs) for the current genesis file source.
+{% endhint %}
 
 ### Sync
 
-The fastest way to join the network is by downloading a current snapshot and sync from it.
+The fastest way to join the network is by downloading a current snapshot and syncing from it.
 
-As `thornode` user run:
-
-```sh
-# get latest snapshot
-FILENAME=$(curl -s "https://snapshots.ninerealms.com/snapshots?prefix=thornode" | grep -Eo "thornode/[0-9]+.tar.gz" | sort -n | tail -n 1 | cut -d "/" -f 2)
-
-# download snapshot
-aria2c --split=16 --max-concurrent-downloads=16 --max-connection-per-server=16 --continue --min-split-size=100M -d $HOME/.thornode -o $FILENAME "https://snapshots.ninerealms.com/snapshots/thornode/${FILENAME}"
-
-# ensure no chain data exists
-rm -rf $HOME/.thornode/data/{*.db,snapshot,cs.wal}
-
-# extract snapshot
-pv $HOME/.thornode/$FILENAME | tar -xzf - -C $HOME/.thornode --exclude "*_state.json"
-
-# cleanup snapshot
-rm -rf $HOME/.thornode/$FILENAME
-```
+{% hint style="warning" %}
+Nine Realms infrastructure has been decommissioned. Refer to the upstream [Thornode Snapshot Recovery and Storage Management](https://gitlab.com/thorchain/devops/node-launcher/-/blob/master/docs/Thornode-Snapshot-Recovery-and-Storage-Management.md) doc for the current snapshot source and recovery procedure.
+{% endhint %}
 
 ## Systemd
 

--- a/thornodes/joining.md
+++ b/thornodes/joining.md
@@ -50,7 +50,7 @@ BCH         2.293%     197,340/682,404
 
 Your node is running but as you can see in the \`Preflight\` section, your node is not yet ready to be churned in and currently is in standby [status](overview/node-operations.md#node-statuses), since your node has no IP address setup yet.
 
-Do not proceed until your node is fully synced al chains. You can see the required external chain hights [here](https://thornode.ninerealms.com/thorchain/lastblock) and the THORChain chain height [here](https://thornode.ninerealms.com/thorchain/block). Continue to run `make status` untill all chains are synced.
+Do not proceed until your node is fully synced across all chains. You can see the required external chain heights [here](https://gateway.liquify.com/chain/thorchain_api/thorchain/lastblock) and the THORChain chain height [here](https://gateway.liquify.com/chain/thorchain_api/thorchain/block). Continue to run `make status` until all chains are synced.
 
 {% hint style="danger" %}
 Before sending the BOND, verify that your THORNode is **fully synced** with connected chains. Connected chains such as Ethereum & Bitcoin may take a day to sync. If your node is fully bonded and is selected to churn in to THORChain as ACTIVE without fully syncing all connected chains, you will immediately get slashed for missing observations, and lose money. It is normal to see Ethereum sit on 99.999% for many hours - be patient.
@@ -76,7 +76,7 @@ Some `make` commands during setup require RUNE (0.02 to 1.0) to execute into the
 Give the network 3-5 seconds to pick up your bond. To verify it has received your bond, run the following:
 
 ```bash
-curl https://thornode.ninerealms.com/thorchain/node/<node-address>
+curl https://gateway.liquify.com/chain/thorchain_api/thorchain/node/<node-address>
 ```
 
 If you run `make status` again, you should see this:
@@ -151,7 +151,7 @@ If you followed steps 1-5 above, your preflight will be saying:
 PREFLIGHT   { "status": "Standby", "reason": "node account does not have minimum bond requirement: 100000000000/30000000000000, "code": 1 }
 ```
 
-To address this, send the remaining bond, that is higher than the minimum bond, currently 300K RUNE set by a network [Mimir ](https://thornode.ninerealms.com/thorchain/mimir)setting, look for `MinimumBondInRune`. See [#bonding-the-right-amount](joining.md#bonding-the-right-amount "mention")for how much bond to send.
+To address this, send the remaining bond, that is higher than the minimum bond, currently 300K RUNE set by a network [Mimir ](https://gateway.liquify.com/chain/thorchain_api/thorchain/mimir)setting, look for `MinimumBondInRune`. See [#bonding-the-right-amount](joining.md#bonding-the-right-amount "mention")for how much bond to send.
 
 If you finally run `make status` you should see this, with keyword **"Ready":**
 
@@ -186,7 +186,7 @@ Although your node is ready to be churned in, it doesn’t mean it will be the n
 This endpoint will show data on average, median, total, minimum and maximum bond amounts. For fastest entry, bond higher than the current active median.
 
 ```json
-curl -s https://midgard.ninerealms.com/v2/network | jq '.bondMetrics'
+curl -s https://gateway.liquify.com/chain/thorchain_midgard/v2/network | jq '.bondMetrics'
 
 resp:
  "bondMetrics" : {

--- a/thornodes/leaving.md
+++ b/thornodes/leaving.md
@@ -6,7 +6,7 @@ description: How to leave THORChain
 
 ## Overview
 
-Approximately every 2 1/2 days (43,200 blocks or [`CHURNINTERVAL`](https://thornode.ninerealms.com/thorchain/mimir)) the system will churn its vaults and nodes.
+Approximately every 2 1/2 days (43,200 blocks or [`CHURNINTERVAL`](https://gateway.liquify.com/chain/thorchain_api/thorchain/mimir)) the system will churn its vaults and nodes.
 
 Outgoing nodes consist of:
 
@@ -18,7 +18,7 @@ Note: Just less than 1/3 of the active network can be churned out in a single ch
 
 Incoming:
 
-1. The node(s) with the highest bond (2 or [`NUMBEROFNEWNODESPERCHURN`](https://thornode.ninerealms.com/thorchain/mimir)).
+1. The node(s) with the highest bond (2 or [`NUMBEROFNEWNODESPERCHURN`](https://gateway.liquify.com/chain/thorchain_api/thorchain/mimir)).
 
 Churned out nodes will be put in standby, but their bond will not automatically be returned. They will be credited any earned rewards in their last session. If they do nothing, but keep their cluster online and up-to-date with the latest THORNode version, they will be eventually churn back in.
 

--- a/thornodes/overview/node-operations.md
+++ b/thornodes/overview/node-operations.md
@@ -8,7 +8,7 @@ description: Running a THORNode
 
 As new nodes join/leave the network, this triggers a “churning event”. Which means the list of validators that can commit blocks to the chain changes, and also creates a new Asgard vault, while retiring an old one. All funds in this retiring vault are moved to the new Asgard vault.
 
-Normally, a churning event happens roughly every 2 1/2 days (43,200 blocks or [`CHURNINTERVAL`](https://thornode.ninerealms.com/thorchain/mimir)).
+Normally, a churning event happens roughly every 2 1/2 days (43,200 blocks or [`CHURNINTERVAL`](https://gateway.liquify.com/chain/thorchain_api/thorchain/mimir)).
 
 Nodes that targged for the next churn in and out can be seen [here](https://thorchain.network/nodes). The next churn interval can be seen [here](https://thorchain.net/nodes).
 
@@ -20,7 +20,7 @@ On every churn, the network selects one or more nodes to be churned out of the n
 2. Banned by other nodes (network-removal)
 3. How long an active nodes has been committing blocks (oldest gets removed)
 4. Bad behavior (accrued slash points for poor node operation)
-5. Nodes that do not meet the minimum version requirement (capped by [`MAXNODETOCHURNOUTFORLOWVERSION`](https://thornode.ninerealms.com/thorchain/mimir))
+5. Nodes that do not meet the minimum version requirement (capped by [`MAXNODETOCHURNOUTFORLOWVERSION`](https://gateway.liquify.com/chain/thorchain_api/thorchain/mimir))
 
 #### Churning In
 
@@ -96,7 +96,7 @@ http://<host>:1317/thorchain/nodeaccount/<node address>
 http://<host>:1317/thorchain/nodeaccounts
 ```
 
-Or use `https://thornode.ninerealms.com/thorchain/node/<node address>.`
+Or use `https://gateway.liquify.com/chain/thorchain_api/thorchain/node/<node address>.`
 
 Most importantly, this will tell you how many slash points the node account has accrued, their status, and the size of their bond (which is in 1e8 notation, 1 Rune == 100000000).
 

--- a/thornodes/overview/thornode-stack.md
+++ b/thornodes/overview/thornode-stack.md
@@ -17,14 +17,14 @@ Endpoints can be accessed at [Connecting to THORChain in the developer docs](htt
 
 ## THORNode Endpoints
 
-The THORNode daemon contains three endpoints that run on port `1317` or can be access via the public URL [https://thornode.ninerealms.com/](https://thornode.ninerealms.com/).
+The THORNode daemon contains three endpoints that run on port `1317` or can be access via the public URL [https://gateway.liquify.com/chain/thorchain_api/](https://gateway.liquify.com/chain/thorchain_api/).
 
 - **`<tc:1317>/thorchain`**:
-  - This endpoint deals specifically with THORChain's native modules and functionality. It provides access to THORChain-specific data such as liquidity pools, nodes, and network configurations. This is where you'll find THORChain-specific operations and data that aren't part of the underlying Cosmos SDK but are unique to THORChain. [`thorchain/doc/`](https://thornode.ninerealms.com/thorchain/doc/) contains Swagger documentation for the `thorchain` endpont.
+  - This endpoint deals specifically with THORChain's native modules and functionality. It provides access to THORChain-specific data such as liquidity pools, nodes, and network configurations. This is where you'll find THORChain-specific operations and data that aren't part of the underlying Cosmos SDK but are unique to THORChain. [`thorchain/doc/`](https://gateway.liquify.com/chain/thorchain_api/thorchain/doc/) contains Swagger documentation for the `thorchain` endpont.
 - **`<tc:1317>/cosmos`**:
-  - This endpoint interfaces with the [Cosmos SDK](../../technology/cosmos-sdk.md). It provides access to Cosmos SDK endpoints that THORChain inherits by being built on the Cosmos SDK. The endpoints are version specific and the CosmosSDK version THORChain uses can be found at [here](https://gitlab.com/thorchain/thornode/-/blob/develop/go.mod?ref_type=heads#L17). Tendermint informaiton can also be accessed via `cosmos/base/tendermint` - [`node_info` example](https://thornode.ninerealms.com/cosmos/base/tendermint/v1beta1/node_info).
+  - This endpoint interfaces with the [Cosmos SDK](../../technology/cosmos-sdk.md). It provides access to Cosmos SDK endpoints that THORChain inherits by being built on the Cosmos SDK. The endpoints are version specific and the CosmosSDK version THORChain uses can be found at [here](https://gitlab.com/thorchain/thornode/-/blob/develop/go.mod?ref_type=heads#L17). Tendermint informaiton can also be accessed via `cosmos/base/tendermint` - [`node_info` example](https://gateway.liquify.com/chain/thorchain_api/cosmos/base/tendermint/v1beta1/node_info).
 - **`<tc:1317>/bank`**:
-  - The `bank` module in Cosmos SDK handles token transfers and balances. The `<tc:1317>/bank` endpoint allows you to interact with accounts, check balances, and transfer assets. See example [here](https://thornode.ninerealms.com/bank/balances/thor1dheycdevq39qlkxs2a6wuuzyn4aqxhve4qxtxt).
+  - The `bank` module in Cosmos SDK handles token transfers and balances. The `<tc:1317>/bank` endpoint allows you to interact with accounts, check balances, and transfer assets. See example [here](https://gateway.liquify.com/chain/thorchain_api/bank/balances/thor1dheycdevq39qlkxs2a6wuuzyn4aqxhve4qxtxt).
 
 ## THORNode Keys
 
@@ -52,7 +52,7 @@ It is critical backups are created matinaned, if there are any questions, reach 
 
 Every few years, THORChain conducts a hardfork. During a hardfork, THORChain's data is moved to an archive, and the chain begins running on a new chain ID. This process ensures that the blockchain continues to operate efficiently and scales with the network's growth.
 
-- **Chain ID**: The current `chainid` can be accessed via [`https://rpc.ninerealms.com/status`](https://rpc.ninerealms.com/status) or by querying the `<tc:26657>/status` endpoint on a specific node.
+- **Chain ID**: The current `chainid` can be accessed via [`https://gateway.liquify.com/chain/thorchain_rpc/status`](https://gateway.liquify.com/chain/thorchain_rpc/status) or by querying the `<tc:26657>/status` endpoint on a specific node.
 
 **Hardfork History**:
 

--- a/understanding-thorchain/roles/liquidity-providers.md
+++ b/understanding-thorchain/roles/liquidity-providers.md
@@ -163,7 +163,7 @@ Liquidity providers can withdraw their assets at any time. The network processes
 
 ## How Yield is Calculated
 
-The yield of a pool on THORChain is calculated using a metric called **Liquidity Unit Value Index** (LUVI) which can be viewed on [Midgard](https://midgard.ninerealms.com/v2/pools).
+The yield of a pool on THORChain is calculated using a metric called **Liquidity Unit Value Index** (LUVI) which can be viewed on [Midgard](https://gateway.liquify.com/chain/thorchain_midgard/v2/pools).
 
 When a user deposits assets into a liquidity pool, they are given ownership of Liquidity Units which represent a percentage of ownership of the pool. LUVI is a measure of the relative value of each liquidity unit and is independent of price.
 
@@ -184,7 +184,7 @@ Learn more about [Liquidity Units](https://docs.thorchain.org/thorchain-finance/
 The yield of a pool uses LUVI value data from the previous 30 days and extrapolates an APR if that performance is repeated over the course of a year. A `period` parameter may be used to change the number of days of data that are taken into consideration.
 
 {% hint style="info" %}
-Example: [https://midgard.ninerealms.com/v2/pools?period=100d](https://midgard.ninerealms.com/v2/pools?period=100d) calculates the APR of a pool with the previous 100 days of data rather than the default of 30 days.
+Example: [https://gateway.liquify.com/chain/thorchain_midgard/v2/pools?period=100d](https://gateway.liquify.com/chain/thorchain_midgard/v2/pools?period=100d) calculates the APR of a pool with the previous 100 days of data rather than the default of 30 days.
 {% endhint %}
 
 Factors that affect LUVI:

--- a/understanding-thorchain/rune.md
+++ b/understanding-thorchain/rune.md
@@ -119,7 +119,7 @@ Learn about the Incentive Pendulum here:
 
 RUNE's price has two factors: a deterministic value based on the liquidity within the network and a speculative premium. The economic security model creates a minimum value floor for RUNE based on the assets it secures. For detailed calculations and economic mechanics, see the [Economic Model](../technical-deep-dive/economic-model.md).
 
-## For more informaiton on RUNE see
+## For more information on RUNE see
 
 - [THORChain Tokenomics Article](https://medium.com/thorchain/thorchain-tokenomics-what-is-rune-52d339633260)
 - [Under the Hood: Rune Supply](https://thorchain-community.medium.com/under-the-hood-rune-supply-d30772fdfbaf)

--- a/understanding-thorchain/rune.md
+++ b/understanding-thorchain/rune.md
@@ -123,5 +123,5 @@ RUNE's price has two factors: a deterministic value based on the liquidity withi
 
 - [THORChain Tokenomics Article](https://medium.com/thorchain/thorchain-tokenomics-what-is-rune-52d339633260)
 - [Under the Hood: Rune Supply](https://thorchain-community.medium.com/under-the-hood-rune-supply-d30772fdfbaf)
-- [Current Supply Data](https://dashboards.ninerealms.com/#lending)
+- [Current Supply Data](https://dashboards.thorchain.org/)
 - [THORChain Tokenomics Dashboard](https://flipsidecrypto.xyz/BlockTracker/thorchain-tokenomics-g7ZOP_)


### PR DESCRIPTION
### Domain replacements

| Old | New |
|---|---|
| `thornode.ninerealms.com` | `gateway.liquify.com/chain/thorchain_api` |
| `midgard.ninerealms.com` | `gateway.liquify.com/chain/thorchain_midgard` |
| `rpc.ninerealms.com` | `gateway.liquify.com/chain/thorchain_rpc` |
| `track.ninerealms.com` | `track.thorchain.org` |
| `dashboards.ninerealms.com` | `dashboards.thorchain.org` |

Path components are preserved across the swap (e.g. `/thorchain/constants` → `gateway.liquify.com/chain/thorchain_api/thorchain/constants`). Mappings sourced from [node-launcher!1597](https://gitlab.com/thorchain/devops/node-launcher/-/merge_requests/1597) and confirmed against the ASGARDEX desktop client's mainnet config.

### Operational sections without a confirmed replacement

The Linux/Docker setup guides under `thornodes/fullnode/` previously included paste-able commands for downloading snapshots, fetching the genesis file, and configuring statesync seeds. None of these have a confirmed Liquify equivalent yet — per node-launcher!1597, "the only remaining Nine Realms links are those for the Midgard Blockstore snapshots, which the team states Liquify is still addressing." Statesync seed peer IDs and the `public-snapshots-ninerealms` GCS bucket are similarly in limbo.

Rather than ship broken commands that node operators would copy-paste, those sections now contain warning hints pointing to the upstream [node-launcher docs](https://gitlab.com/thorchain/devops/node-launcher/-/tree/master/docs) and the [Thornode Snapshot Recovery and Storage Management](https://gitlab.com/thorchain/devops/node-launcher/-/blob/master/docs/Thornode-Snapshot-Recovery-and-Storage-Management.md) doc, where the canonical setup instructions will live as the migration completes.

Affected files:

- `thornodes/fullnode/thornode-linux.md` — Seed nodes, Genesis, and Sync sections replaced with hint blocks
- `thornodes/fullnode/thornode-docker.md` — Genesis and Sync sections replaced with hint blocks
- `thornodes/fullnode/midgard-linux.md` — genesis curl removed; `blockstore.remote` JSON field set to empty string with an inline warning
- `thornodes/fullnode/midgard-docker.md` — same treatment as midgard-linux
- `thornodes/fullnode/README.md` — top-of-page banner added flagging the partial state of the Linux/Docker guides

The `blockstore.remote` field in the Midgard JSON examples is left as an empty string rather than a stale URL — pointing Midgard at a dead `ninerealms.com` endpoint would silently break new deployments, while empty + warning makes the missing config explicit.

### Drive-by fixes

- `frequently-asked-questions/README.md` — dropped dead `ops.ninerealms.com/network` link (runescan kept as the canonical alternative), fixed `hhttps` typo on the runescan link, fixed `pararamter` → `parameter`
- `thornodes/joining.md` — fixed `synced al chains` → `synced across all chains`, `hights` → `heights`, `untill` → `until`
- `understanding-thorchain/rune.md` — dropped the wrong `#lending` anchor on the "Current Supply Data" link (the anchor was for the lending dashboard, not the supply page)
- `archived/lending.md` — "Lending Health Dashboard by NineRealms" → "Lending Health Dashboard" (the link now points at `thorchain.org`, so the original attribution would be misleading)

## Follow-up

A subsequent PR will inline the actual snapshot URLs, statesync seed peer IDs, and genesis source once Liquify publishes them. 