### PR TITLE
fix(docs): repair Docker fullnode guide (stale image, genesis, statesync)

### DIFF
--- a/thornodes/fullnode/thornode-docker.md
+++ b/thornodes/fullnode/thornode-docker.md
@@ -18,6 +18,10 @@ Install all packages needed for running and configuring the THORNode container
 apt install -y --no-install-recommends aria2 curl docker.io jq pv
 ```
 
+{% hint style="info" %}
+The published image is built for `linux/amd64`. On an `arm64` host (e.g. Apple Silicon) add `--platform linux/amd64` to the `docker run` command to run it under emulation.
+{% endhint %}
+
 ## Configuration
 
 ### Work directory
@@ -30,21 +34,31 @@ mkdir -p /opt/thornode/.thornode/config
 
 ### Genesis
 
-For joining the network, the correct genesis file is required.
-
-{% hint style="warning" %}
-Nine Realms infrastructure has been decommissioned. Refer to the upstream [node-launcher documentation](https://gitlab.com/thorchain/devops/node-launcher/-/tree/master/docs) for the current genesis file source.
-{% endhint %}
+No manual step is required. On first start the container fetches the genesis file automatically from the network's seed nodes (discovered via the configured seed-nodes endpoint, then pulled from a peer's RPC). A successful genesis fetch is **not** by itself enough to join the network — you must also choose a sync method below, otherwise the node will attempt to initialize from the fetched genesis and fail.
 
 ### Sync
 
-The fastest way to join the network is by downloading a current snapshot and syncing from it.
+A fullnode cannot replay the chain from genesis with a current binary; you must bootstrap from a recent state. Choose one of the following.
+
+#### Option A — Automatic StateSync (self-contained)
+
+Set `THOR_AUTO_STATE_SYNC_ENABLED=true` (included in the `docker run` below). The node determines a trust height from the default trusted RPC servers and restores recent state over P2P from StateSync peers.
 
 {% hint style="warning" %}
-Nine Realms infrastructure has been decommissioned. Refer to the upstream [Thornode Snapshot Recovery and Storage Management](https://gitlab.com/thorchain/devops/node-launcher/-/blob/master/docs/Thornode-Snapshot-Recovery-and-Storage-Management.md) doc for the current snapshot source and recovery procedure.
+Network StateSync is memory intensive — at the time of writing it requires roughly `80 GB` of RAM. Ensure your server is sized accordingly.
+{% endhint %}
+
+#### Option B — Snapshot restore
+
+Download a current snapshot and extract it into `/opt/thornode/.thornode/data` before starting the container (leave `THOR_AUTO_STATE_SYNC_ENABLED` unset in this case). For snapshot sources and the recovery procedure, see the upstream [Thornode Snapshot Recovery and Storage Management](https://gitlab.com/thorchain/devops/node-launcher/-/blob/master/docs/Thornode-Snapshot-Recovery-and-Storage-Management.md) doc.
+
+{% hint style="info" %}
+That document is written for the Kubernetes/Helm `node-launcher` deployment (it uses `make` targets); for a standalone Docker node use it only as the source of the snapshot location and storage guidance, and place the extracted data under the mounted `.thornode/data` directory.
 {% endhint %}
 
 ## Start
+
+Use the image tag that matches the current network version (check `/thorchain/version` on a public node). At the time of writing this is `mainnet-3.18.1`.
 
 Start the thornode container
 
@@ -52,9 +66,14 @@ Start the thornode container
 docker run -d --restart=on-failure \
   -v /opt/thornode/.thornode:/root/.thornode \
   -e CHAIN_ID=thorchain-1 \
+  -e THOR_AUTO_STATE_SYNC_ENABLED=true \
   -p 127.0.0.1:1317:1317 \
   -p 127.0.0.1:27147:27147 \
   -p 27146:27146 \
   --name thornode \
-  registry.gitlab.com/thorchain/thornode:mainnet-2.135.1 
+  registry.gitlab.com/thorchain/thornode:mainnet-3.18.1
 ```
+
+{% hint style="info" %}
+On `arm64` hosts add `--platform linux/amd64`. If you bootstrapped via a snapshot (Option B) instead of StateSync, remove the `-e THOR_AUTO_STATE_SYNC_ENABLED=true` line.
+{% endhint %}


### PR DESCRIPTION
## Summary
The **Thornode on Docker** fullnode page (`thornodes/fullnode/thornode-docker.md`) does not produce a working node as written. I verified this by actually running the documented procedure; this PR fixes it.

## What I found (empirically)
- **Documented image `mainnet-2.135.1` crash-loops.** Its baked-in seed source is the decommissioned Nine Realms host (`api.ninerealms.com/thorchain/seeds`), which no longer resolves → no seeds → genesis self-fetch is skipped → `couldn't read GenesisDoc file ... no such file` → restart loop.
- **Genesis is fetched automatically** from seed peers (`/genesis_chunked`) by current binaries — the manual "get genesis from node-launcher" instruction is non-actionable, and a successful genesis fetch alone is not enough to join.
- **A current binary cannot init from the fetched genesis.** With a current image (`mainnet-3.18.1`) the genesis self-fetch succeeds (40 MB state-export), but `InitChain` then panics: `panic: invalid address` in `x/bank InitGenesis` → crash loop.
- **StateSync is the working bootstrap path, but it is off by default and undocumented here.** Setting `THOR_AUTO_STATE_SYNC_ENABLED=true` changes the outcome: the node sets a trust height from the default RPC servers and reaches `Discovering snapshots` with 0 restarts and no panic (verified). Completing a statesync needs substantial RAM (~80 GB per node-launcher).
- The linked node-launcher snapshot doc is **Kubernetes/Helm `make`-based** with no docker-compatible procedure.
- The published image is **amd64-only**; arm64 hosts need `--platform linux/amd64`.

## Changes
- Bump the example image tag to a current version and tell operators to track the network version.
- Rewrite the **Genesis** section: it's automatic; no manual step.
- Rewrite the **Sync** section: document StateSync (`THOR_AUTO_STATE_SYNC_ENABLED=true`, with RAM caveat) and a snapshot-restore alternative (noting the linked doc is k8s/make-based).
- Add the StateSync env var to the `docker run` example and an arm64 `--platform` note.

## Not fully verified
A complete statesync was not run to tip (requires ~80 GB RAM / large disk); verification reached `Discovering snapshots`. Maintainers may prefer a different pinned image tag than `mainnet-3.18.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)