### PR TITLE
Add agent discovery metadata for docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# THORChain Documentation Agent Instructions
+
+## Purpose
+
+Use this site to research THORChain concepts, node operations, integrations, and public API behavior.
+
+## Source priority
+
+Prefer evidence in this order:
+
+1. Current live network responses.
+2. Current official THORChain documentation.
+3. Current THORChain source code and release notes.
+4. Third-party gateway behavior.
+5. Assumptions.
+
+State clearly when information is historical, deprecated, inferred, or unverified.
+
+## Safe behavior
+
+- Default to read-only requests.
+- Never request, store, reveal, or transmit seed phrases, mnemonics, private keys, or signing secrets.
+- Never sign or broadcast a transaction without explicit user approval.
+- Before presenting a transaction for signature, show the network, asset, destination, memo, amount, fees, expiry, and expected effect.
+- Treat public gateway responses as observations, not as a guarantee of future state.
+- Identify deprecated features and do not recommend them as current functionality.
+
+## Retrieval
+
+- Request any documentation page with `Accept: text/markdown` when Markdown is preferred.
+- Start broad research with `https://docs.thorchain.org/llms.txt`.
+- Use `https://docs.thorchain.org/llms-full.txt` only when the larger corpus is necessary.
+- Use the read-only MCP endpoint at `https://docs.thorchain.org/~gitbook/mcp` for documentation queries.
+
+## Answer quality
+
+- Cite the exact documentation page used.
+- Separate protocol rules from wallet, interface, or infrastructure-provider behavior.
+- Include the observation time when reporting live network state.
+- If sources conflict, show the conflict instead of silently choosing one.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -82,6 +82,11 @@
   - [Savers FAQ (Deprecated)](archived/savers-faq.md)
   - [Lending FAQ (Deprecated)](archived/lending-faq.md)
 
+## Agent Access
+
+- [Authentication and Safety](auth.md)
+- [Agent Instructions](AGENTS.md)
+
 - [Website](https://thorchain.org/)
 - [Community Telegram](https://t.me/thorchain_org)
 - [Developer Discord](https://discord.gg/7RRmc35UEG)

--- a/agent-skills/thorchain-docs-research/SKILL.md
+++ b/agent-skills/thorchain-docs-research/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: thorchain-docs-research
+description: Research THORChain using official documentation and read-only public interfaces. Use for protocol concepts, integrations, node operations, public API discovery, and evidence-backed THORChain answers.
+---
+
+# THORChain Documentation Research
+
+## Goal
+
+Answer THORChain questions with current, traceable evidence while avoiding unsafe transaction or key-handling behavior.
+
+## Workflow
+
+1. Start with `https://docs.thorchain.org/llms.txt` to locate the relevant official page.
+2. Fetch the selected page with `Accept: text/markdown`.
+3. Use `https://docs.thorchain.org/~gitbook/mcp` when a documentation search or cross-page synthesis is needed.
+4. For live state, use a read-only THORNode or Midgard `GET` endpoint and record the observation time.
+5. Cite the official documentation page and identify any live endpoint used.
+6. Separate observed facts, documentation statements, and inferences.
+
+## Safety rules
+
+- Never ask for or handle seed phrases, mnemonics, private keys, or signing secrets.
+- Do not sign or broadcast transactions.
+- Do not treat third-party gateways as authoritative infrastructure for production.
+- Require explicit human review before any value-moving action.
+- Flag deprecated features and version-sensitive claims.
+
+## Failure handling
+
+- If a public gateway is unavailable, report that failure and try another documented read-only source.
+- If documentation and live behavior conflict, report both with timestamps.
+- If the requested action would change state, stop at a reviewable transaction plan.

--- a/auth.md
+++ b/auth.md
@@ -1,0 +1,35 @@
+# Auth.md
+
+## Public access
+
+The THORChain documentation is public. Reading its HTML pages, Markdown representations, `llms.txt`, `llms-full.txt`, and documentation MCP server does not require credentials.
+
+## Agent access
+
+Agents do not need to register or provision an account. The supported access methods are unauthenticated HTTPS `GET` and `HEAD` requests for documentation, plus unauthenticated MCP JSON-RPC requests to the documentation MCP endpoint.
+
+Do not send bearer tokens, API keys, wallet credentials, or signing secrets to this documentation service.
+
+## Documentation MCP
+
+- Endpoint: `https://docs.thorchain.org/~gitbook/mcp`
+- Transport: Streamable HTTP
+- Authentication: none
+- Intended use: read-only documentation discovery, search, and retrieval
+
+Clients should initialize the MCP session and discover the available tools through the MCP protocol. Tool availability may change when GitBook updates the published documentation service.
+
+## Public network APIs
+
+The documentation links to public THORNode and Midgard read endpoints. Public gateways may enforce rate limits, change availability, or return network state that changes between requests. Production applications should operate their own infrastructure or use an explicitly supported provider.
+
+## Safety
+
+- Never provide a seed phrase, mnemonic, private key, or signing secret to the documentation site or documentation MCP server.
+- Treat documentation as guidance, not as authorization to sign or broadcast a transaction.
+- Confirm the network, asset, address, memo, amount, fees, and expiry before asking a wallet to sign.
+- Require explicit human confirmation before any state-changing or value-moving action.
+
+## OAuth metadata
+
+This public documentation service does not advertise OAuth or OpenID Connect metadata because it is not an OAuth-protected resource.

--- a/cloudflare/docs-agent-discovery/README.md
+++ b/cloudflare/docs-agent-discovery/README.md
@@ -1,0 +1,20 @@
+# docs.thorchain.org agent discovery Worker
+
+This Worker adds machine-readable discovery without changing GitBook page bodies.
+
+It serves only the documented discovery files, `auth.md`, and `AGENTS.md`; unknown paths pass through to GitBook. The production route set is intentionally limited to the homepage and those exact discovery paths.
+
+## Verify
+
+Run `npm test` in this directory. Before production routing, verify a versioned Preview URL for:
+
+- Homepage body equivalence and the `Link` response header.
+- API catalog media type and Linkset structure.
+- MCP card fields against a live MCP initialization response.
+- Agent skill digest equality.
+- ARD catalog structure and CORS.
+- Unknown-path and MCP POST pass-through behavior.
+
+## Rollback
+
+Remove only the four routes declared in `wrangler.jsonc`. The GitBook CNAME remains unchanged, so removing the routes immediately returns traffic to the prior origin behavior. Keep the Worker version available until post-rollback checks pass.

--- a/cloudflare/docs-agent-discovery/README.md
+++ b/cloudflare/docs-agent-discovery/README.md
@@ -18,3 +18,19 @@ Run `npm test` in this directory. Before production routing, verify a versioned 
 ## Rollback
 
 Remove only the four routes declared in `wrangler.jsonc`. The GitBook CNAME remains unchanged, so removing the routes immediately returns traffic to the prior origin behavior. Keep the Worker version available until post-rollback checks pass.
+
+Delete only the SVCB record declared in `dns-aid-record.json` to roll back DNS-AID. Its TTL is 300 seconds.
+
+## Production verification
+
+The Worker routes and DNS-AID record were activated on 2026-08-26 after the versioned Preview URL passed the public scanner at Level 4. Post-deployment checks confirmed:
+
+- The homepage body SHA-256 remained unchanged.
+- HTML and Markdown homepage responses remained available.
+- Representative ordinary documentation routes and `robots.txt` remained available.
+- MCP initialization still returned protocol version `2025-06-18` with the verified server identity and tool capability.
+- The published Agent Skill digest matched the served bytes.
+- Cloudflare and Google resolvers returned `AD=true` for the DNS-AID SVCB record.
+- A fresh production scan classified the site as Level 4, `Agent-Integrated`.
+
+OAuth, A2A, registration, WebMCP, and payment metadata remain absent because this public documentation service does not provide those capabilities.

--- a/cloudflare/docs-agent-discovery/dns-aid-record.json
+++ b/cloudflare/docs-agent-discovery/dns-aid-record.json
@@ -1,0 +1,12 @@
+{
+  "type": "SVCB",
+  "name": "_mcp._agents.docs.thorchain.org",
+  "ttl": 300,
+  "data": {
+    "priority": 1,
+    "target": "docs.thorchain.org.",
+    "value": "mandatory=\"alpn,port\" alpn=\"mcp\" port=\"443\""
+  },
+  "proxied": false,
+  "comment": "DNS-AID discovery for the public THORChain documentation MCP endpoint"
+}

--- a/cloudflare/docs-agent-discovery/package.json
+++ b/cloudflare/docs-agent-discovery/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "docs-thorchain-agent-discovery",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/cloudflare/docs-agent-discovery/src/index.js
+++ b/cloudflare/docs-agent-discovery/src/index.js
@@ -1,0 +1,413 @@
+export const ORIGIN = "https://docs.thorchain.org";
+
+export const AUTH_MD = `# Auth.md
+
+## Public access
+
+The THORChain documentation is public. Reading its HTML pages, Markdown representations, \`llms.txt\`, \`llms-full.txt\`, and documentation MCP server does not require credentials.
+
+## Agent access
+
+Agents do not need to register or provision an account. The supported access methods are unauthenticated HTTPS \`GET\` and \`HEAD\` requests for documentation, plus unauthenticated MCP JSON-RPC requests to the documentation MCP endpoint.
+
+Do not send bearer tokens, API keys, wallet credentials, or signing secrets to this documentation service.
+
+## Documentation MCP
+
+- Endpoint: \`https://docs.thorchain.org/~gitbook/mcp\`
+- Transport: Streamable HTTP
+- Authentication: none
+- Intended use: read-only documentation discovery, search, and retrieval
+
+Clients should initialize the MCP session and discover the available tools through the MCP protocol. Tool availability may change when GitBook updates the published documentation service.
+
+## Public network APIs
+
+The documentation links to public THORNode and Midgard read endpoints. Public gateways may enforce rate limits, change availability, or return network state that changes between requests. Production applications should operate their own infrastructure or use an explicitly supported provider.
+
+## Safety
+
+- Never provide a seed phrase, mnemonic, private key, or signing secret to the documentation site or documentation MCP server.
+- Treat documentation as guidance, not as authorization to sign or broadcast a transaction.
+- Confirm the network, asset, address, memo, amount, fees, and expiry before asking a wallet to sign.
+- Require explicit human confirmation before any state-changing or value-moving action.
+
+## OAuth metadata
+
+This public documentation service does not advertise OAuth or OpenID Connect metadata because it is not an OAuth-protected resource.
+`;
+
+export const AGENTS_MD = `# THORChain Documentation Agent Instructions
+
+## Purpose
+
+Use this site to research THORChain concepts, node operations, integrations, and public API behavior.
+
+## Source priority
+
+Prefer evidence in this order:
+
+1. Current live network responses.
+2. Current official THORChain documentation.
+3. Current THORChain source code and release notes.
+4. Third-party gateway behavior.
+5. Assumptions.
+
+State clearly when information is historical, deprecated, inferred, or unverified.
+
+## Safe behavior
+
+- Default to read-only requests.
+- Never request, store, reveal, or transmit seed phrases, mnemonics, private keys, or signing secrets.
+- Never sign or broadcast a transaction without explicit user approval.
+- Before presenting a transaction for signature, show the network, asset, destination, memo, amount, fees, expiry, and expected effect.
+- Treat public gateway responses as observations, not as a guarantee of future state.
+- Identify deprecated features and do not recommend them as current functionality.
+
+## Retrieval
+
+- Request any documentation page with \`Accept: text/markdown\` when Markdown is preferred.
+- Start broad research with \`https://docs.thorchain.org/llms.txt\`.
+- Use \`https://docs.thorchain.org/llms-full.txt\` only when the larger corpus is necessary.
+- Use the read-only MCP endpoint at \`https://docs.thorchain.org/~gitbook/mcp\` for documentation queries.
+
+## Answer quality
+
+- Cite the exact documentation page used.
+- Separate protocol rules from wallet, interface, or infrastructure-provider behavior.
+- Include the observation time when reporting live network state.
+- If sources conflict, show the conflict instead of silently choosing one.
+`;
+
+export const SKILL_MD = `---
+name: thorchain-docs-research
+description: Research THORChain using official documentation and read-only public interfaces. Use for protocol concepts, integrations, node operations, public API discovery, and evidence-backed THORChain answers.
+---
+
+# THORChain Documentation Research
+
+## Goal
+
+Answer THORChain questions with current, traceable evidence while avoiding unsafe transaction or key-handling behavior.
+
+## Workflow
+
+1. Start with \`https://docs.thorchain.org/llms.txt\` to locate the relevant official page.
+2. Fetch the selected page with \`Accept: text/markdown\`.
+3. Use \`https://docs.thorchain.org/~gitbook/mcp\` when a documentation search or cross-page synthesis is needed.
+4. For live state, use a read-only THORNode or Midgard \`GET\` endpoint and record the observation time.
+5. Cite the official documentation page and identify any live endpoint used.
+6. Separate observed facts, documentation statements, and inferences.
+
+## Safety rules
+
+- Never ask for or handle seed phrases, mnemonics, private keys, or signing secrets.
+- Do not sign or broadcast transactions.
+- Do not treat third-party gateways as authoritative infrastructure for production.
+- Require explicit human review before any value-moving action.
+- Flag deprecated features and version-sensitive claims.
+
+## Failure handling
+
+- If a public gateway is unavailable, report that failure and try another documented read-only source.
+- If documentation and live behavior conflict, report both with timestamps.
+- If the requested action would change state, stop at a reviewable transaction plan.
+`;
+
+export const API_CATALOG = {
+  linkset: [
+    {
+      anchor: "https://gateway.liquify.com/chain/thorchain_api/thorchain",
+      "service-desc": [
+        {
+          href: "https://gateway.liquify.com/chain/thorchain_api/thorchain/doc/openapi.yaml",
+          type: "application/vnd.oai.openapi;version=3.0",
+          title: "THORNode OpenAPI 3.0 description",
+        },
+      ],
+      "service-doc": [
+        {
+          href: "https://docs.thorchain.org/thornodes/overview.md",
+          type: "text/markdown",
+          title: "THORNode documentation",
+        },
+      ],
+      status: [
+        {
+          href: "https://gateway.liquify.com/chain/thorchain_api/thorchain/lastblock",
+          type: "application/json",
+          title: "THORNode live block status",
+        },
+      ],
+    },
+    {
+      anchor: "https://gateway.liquify.com/chain/thorchain_midgard/v2",
+      "service-desc": [
+        {
+          href: "https://gateway.liquify.com/chain/thorchain_midgard/v2/swagger.json",
+          type: "application/vnd.oai.openapi+json;version=3.0",
+          title: "Midgard OpenAPI 3.0 description",
+        },
+      ],
+      "service-doc": [
+        {
+          href: "https://docs.thorchain.org/technical-documentation/technology/midgard.md",
+          type: "text/markdown",
+          title: "Midgard documentation",
+        },
+      ],
+      status: [
+        {
+          href: "https://gateway.liquify.com/chain/thorchain_midgard/v2/health",
+          type: "application/json",
+          title: "Midgard health",
+        },
+      ],
+    },
+  ],
+};
+
+export const MCP_SERVER_CARD = {
+  version: "1.0",
+  protocolVersion: "2025-06-18",
+  serverInfo: {
+    name: "mcp-typescript server on vercel",
+    title: "THORChain Documentation MCP",
+    version: "0.1.0",
+  },
+  description:
+    "Read-only search and retrieval for the published THORChain documentation.",
+  documentationUrl: `${ORIGIN}/auth.md`,
+  transport: {
+    type: "streamable-http",
+    endpoint: "/~gitbook/mcp",
+  },
+  capabilities: {
+    tools: {
+      listChanged: true,
+    },
+  },
+  authentication: {
+    required: false,
+    schemes: [],
+  },
+  instructions:
+    "Use the server for read-only THORChain documentation research. Discover tools after initialization.",
+};
+
+export const ARD_CATALOG = {
+  specVersion: "1.0",
+  host: {
+    displayName: "THORChain Documentation",
+    identifier: "did:web:docs.thorchain.org",
+  },
+  entries: [
+    {
+      identifier: "urn:air:docs.thorchain.org:server:documentation-mcp",
+      displayName: "THORChain Documentation MCP Server",
+      type: "application/json",
+      url: `${ORIGIN}/.well-known/mcp/server-card.json`,
+      representativeQueries: [
+        "How does THORChain execute native cross-chain swaps?",
+        "What are the requirements for operating a THORNode?",
+        "How should an integration query THORChain documentation?",
+      ],
+    },
+    {
+      identifier: "urn:air:docs.thorchain.org:catalog:public-apis",
+      displayName: "THORChain Public API Catalog",
+      type: "application/linkset+json",
+      url: `${ORIGIN}/.well-known/api-catalog`,
+      representativeQueries: [
+        "Where is the THORNode OpenAPI description?",
+        "How can I discover the Midgard API and health endpoint?",
+      ],
+    },
+  ],
+};
+
+const SKILL_PATH =
+  "/.well-known/agent-skills/thorchain-docs-research/SKILL.md";
+const MCP_CARD_PATHS = new Set([
+  "/.well-known/mcp/server-card.json",
+  "/.well-known/mcp/server-cards.json",
+  "/.well-known/mcp.json",
+]);
+const encoder = new TextEncoder();
+const skillDigestPromise = crypto.subtle
+  .digest("SHA-256", encoder.encode(SKILL_MD))
+  .then(toHex);
+
+function toHex(buffer) {
+  return [...new Uint8Array(buffer)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function skillIndex() {
+  return {
+    $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+    skills: [
+      {
+        name: "thorchain-docs-research",
+        type: "skill-md",
+        description:
+          "Research THORChain using official documentation and read-only public interfaces. Use for protocol concepts, integrations, node operations, public API discovery, and evidence-backed THORChain answers.",
+        url: `${ORIGIN}${SKILL_PATH}`,
+        digest: `sha256:${await skillDigestPromise}`,
+      },
+    ],
+  };
+}
+
+function discoveryHeaders(contentType) {
+  return new Headers({
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+    "Access-Control-Allow-Origin": "*",
+    "Cache-Control": "public, max-age=3600",
+    "Content-Type": contentType,
+    "X-Content-Type-Options": "nosniff",
+  });
+}
+
+function bodyFor(request, body) {
+  return request.method === "HEAD" ? null : body;
+}
+
+function textResponse(request, body, contentType = "text/markdown; charset=utf-8") {
+  return new Response(bodyFor(request, body), {
+    status: 200,
+    headers: discoveryHeaders(contentType),
+  });
+}
+
+function jsonResponse(request, value, contentType = "application/json; charset=utf-8", extraHeaders = {}) {
+  const headers = discoveryHeaders(contentType);
+  for (const [name, value] of Object.entries(extraHeaders)) {
+    headers.set(name, value);
+  }
+
+  return new Response(bodyFor(request, JSON.stringify(value, null, 2)), {
+    status: 200,
+    headers,
+  });
+}
+
+function isSyntheticPath(pathname) {
+  return (
+    pathname === "/auth.md" ||
+    pathname === "/AGENTS.md" ||
+    pathname === "/.well-known/api-catalog" ||
+    pathname === "/.well-known/agent-skills/index.json" ||
+    pathname === SKILL_PATH ||
+    pathname === "/.well-known/ai-catalog.json" ||
+    MCP_CARD_PATHS.has(pathname)
+  );
+}
+
+async function upstreamRequest(request) {
+  const url = new URL(request.url);
+  if (url.hostname === "docs.thorchain.org") {
+    return request;
+  }
+
+  url.protocol = "https:";
+  url.host = "docs.thorchain.org";
+  const headers = new Headers(request.headers);
+  headers.delete("authorization");
+  headers.delete("cookie");
+
+  const init = {
+    method: request.method,
+    headers,
+    redirect: request.redirect,
+  };
+
+  if (!new Set(["GET", "HEAD"]).has(request.method)) {
+    init.body = await request.arrayBuffer();
+  }
+
+  return new Request(url, init);
+}
+
+export function homepageLinks() {
+  return [
+    '</llms.txt>; rel="describedby"; type="text/markdown"',
+    '</llms-full.txt>; rel="describedby"; type="text/markdown"',
+    '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+    '</.well-known/mcp/server-card.json>; rel="service-desc"; type="application/json"',
+    '</.well-known/agent-skills/index.json>; rel="service-desc"; type="application/json"',
+    '</.well-known/ai-catalog.json>; rel="describedby"; type="application/json"',
+    '</auth.md>; rel="service-doc"; type="text/markdown"',
+  ].join(", ");
+}
+
+export async function handleRequest(request) {
+  const url = new URL(request.url);
+
+  if (request.method === "OPTIONS" && isSyntheticPath(url.pathname)) {
+    return new Response(null, {
+      status: 204,
+      headers: discoveryHeaders("text/plain; charset=utf-8"),
+    });
+  }
+
+  if (!new Set(["GET", "HEAD"]).has(request.method)) {
+    if (isSyntheticPath(url.pathname)) {
+      return new Response(null, {
+        status: 405,
+        headers: { Allow: "GET, HEAD, OPTIONS" },
+      });
+    }
+    return fetch(await upstreamRequest(request));
+  }
+
+  if (url.pathname === "/auth.md") {
+    return textResponse(request, AUTH_MD);
+  }
+
+  if (url.pathname === "/AGENTS.md") {
+    return textResponse(request, AGENTS_MD);
+  }
+
+  if (url.pathname === "/.well-known/api-catalog") {
+    return jsonResponse(
+      request,
+      API_CATALOG,
+      'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"; charset=utf-8',
+      {
+        Link: `<${ORIGIN}/.well-known/api-catalog>; rel="api-catalog"`,
+      },
+    );
+  }
+
+  if (MCP_CARD_PATHS.has(url.pathname)) {
+    return jsonResponse(request, MCP_SERVER_CARD);
+  }
+
+  if (url.pathname === "/.well-known/agent-skills/index.json") {
+    return jsonResponse(request, await skillIndex());
+  }
+
+  if (url.pathname === SKILL_PATH) {
+    return textResponse(request, SKILL_MD);
+  }
+
+  if (url.pathname === "/.well-known/ai-catalog.json") {
+    return jsonResponse(request, ARD_CATALOG);
+  }
+
+  const upstream = await fetch(await upstreamRequest(request));
+  if (url.pathname !== "/") {
+    return upstream;
+  }
+
+  const response = new Response(upstream.body, upstream);
+  response.headers.append("Link", homepageLinks());
+  return response;
+}
+
+export default {
+  fetch: handleRequest,
+};

--- a/cloudflare/docs-agent-discovery/test/worker.test.mjs
+++ b/cloudflare/docs-agent-discovery/test/worker.test.mjs
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import test from "node:test";
+
+import worker, {
+  AGENTS_MD,
+  AUTH_MD,
+  MCP_SERVER_CARD,
+  ORIGIN,
+  SKILL_MD,
+  handleRequest,
+  homepageLinks,
+  skillIndex,
+} from "../src/index.js";
+
+async function withFetch(mock, callback) {
+  const original = globalThis.fetch;
+  globalThis.fetch = mock;
+  try {
+    return await callback();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+test("module exports the Worker fetch handler", () => {
+  assert.equal(worker.fetch, handleRequest);
+});
+
+test("homepage preserves the upstream body and adds RFC 8288 discovery links", async () => {
+  await withFetch(
+    async (request) => {
+      assert.equal(request.url, `${ORIGIN}/`);
+      return new Response("<html>origin</html>", {
+        status: 200,
+        headers: { "Content-Type": "text/html; charset=utf-8", ETag: '"origin"' },
+      });
+    },
+    async () => {
+      const response = await handleRequest(new Request("https://preview.example/"));
+      assert.equal(response.status, 200);
+      assert.equal(await response.text(), "<html>origin</html>");
+      assert.equal(response.headers.get("etag"), '"origin"');
+      assert.equal(response.headers.get("link"), homepageLinks());
+      assert.match(response.headers.get("link"), /rel="api-catalog"/);
+      assert.match(response.headers.get("link"), /rel="service-desc"/);
+      assert.match(response.headers.get("link"), /rel="service-doc"/);
+    },
+  );
+});
+
+test("API catalog supports GET and HEAD with the RFC 9727 media type", async () => {
+  const url = "https://preview.example/.well-known/api-catalog";
+  const getResponse = await handleRequest(new Request(url));
+  assert.equal(getResponse.status, 200);
+  assert.match(getResponse.headers.get("content-type"), /^application\/linkset\+json/);
+  assert.equal(getResponse.headers.get("access-control-allow-origin"), "*");
+  assert.match(getResponse.headers.get("link"), /rel="api-catalog"/);
+
+  const catalog = await getResponse.json();
+  assert.equal(catalog.linkset.length, 2);
+  for (const entry of catalog.linkset) {
+    assert.ok(entry.anchor);
+    assert.ok(entry["service-desc"]?.length);
+    assert.ok(entry["service-doc"]?.length);
+  }
+
+  const headResponse = await handleRequest(new Request(url, { method: "HEAD" }));
+  assert.equal(headResponse.status, 200);
+  assert.equal(await headResponse.text(), "");
+  assert.match(headResponse.headers.get("content-type"), /^application\/linkset\+json/);
+});
+
+test("MCP card aliases describe the verified GitBook MCP runtime", async () => {
+  for (const path of [
+    "/.well-known/mcp/server-card.json",
+    "/.well-known/mcp/server-cards.json",
+    "/.well-known/mcp.json",
+  ]) {
+    const response = await handleRequest(new Request(`https://preview.example${path}`));
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), MCP_SERVER_CARD);
+  }
+
+  assert.equal(MCP_SERVER_CARD.protocolVersion, "2025-06-18");
+  assert.equal(MCP_SERVER_CARD.serverInfo.name, "mcp-typescript server on vercel");
+  assert.equal(MCP_SERVER_CARD.serverInfo.version, "0.1.0");
+  assert.equal(MCP_SERVER_CARD.transport.endpoint, "/~gitbook/mcp");
+  assert.deepEqual(MCP_SERVER_CARD.capabilities, { tools: { listChanged: true } });
+});
+
+test("Auth.md and AGENTS.md have truthful discovery headings", async () => {
+  const authResponse = await handleRequest(new Request("https://preview.example/auth.md"));
+  assert.equal(await authResponse.text(), AUTH_MD);
+  assert.match(AUTH_MD, /^# Auth\.md/m);
+  assert.match(AUTH_MD, /does not require credentials/);
+
+  const agentsResponse = await handleRequest(new Request("https://preview.example/AGENTS.md"));
+  assert.equal(await agentsResponse.text(), AGENTS_MD);
+  assert.match(AGENTS_MD, /^# THORChain Documentation Agent Instructions/m);
+});
+
+test("skill index digest matches both served and checked-in skill bytes", async () => {
+  const sourcePath = new URL(
+    "../../../agent-skills/thorchain-docs-research/SKILL.md",
+    import.meta.url,
+  );
+  const checkedInSkill = await readFile(sourcePath, "utf8");
+  assert.equal(checkedInSkill, SKILL_MD);
+
+  const index = await skillIndex();
+  const expected = `sha256:${createHash("sha256").update(SKILL_MD).digest("hex")}`;
+  assert.equal(index.skills[0].digest, expected);
+
+  const indexResponse = await handleRequest(
+    new Request("https://preview.example/.well-known/agent-skills/index.json"),
+  );
+  assert.deepEqual(await indexResponse.json(), index);
+
+  const skillResponse = await handleRequest(
+    new Request(
+      "https://preview.example/.well-known/agent-skills/thorchain-docs-research/SKILL.md",
+    ),
+  );
+  assert.equal(await skillResponse.text(), SKILL_MD);
+});
+
+test("ARD manifest is public, CORS-enabled, and structurally valid", async () => {
+  const response = await handleRequest(
+    new Request("https://preview.example/.well-known/ai-catalog.json"),
+  );
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("access-control-allow-origin"), "*");
+  const catalog = await response.json();
+  assert.ok(catalog.specVersion);
+  assert.ok(catalog.host.displayName);
+  assert.ok(catalog.entries.length);
+  for (const entry of catalog.entries) {
+    assert.equal(Number(Boolean(entry.url)) + Number(Boolean(entry.data)), 1);
+    assert.ok(entry.representativeQueries.length >= 2);
+  }
+});
+
+test("synthetic routes support CORS preflight and reject writes", async () => {
+  const url = "https://preview.example/.well-known/api-catalog";
+  const optionsResponse = await handleRequest(new Request(url, { method: "OPTIONS" }));
+  assert.equal(optionsResponse.status, 204);
+  assert.equal(optionsResponse.headers.get("access-control-allow-origin"), "*");
+
+  const postResponse = await handleRequest(new Request(url, { method: "POST" }));
+  assert.equal(postResponse.status, 405);
+  assert.equal(postResponse.headers.get("allow"), "GET, HEAD, OPTIONS");
+});
+
+test("unknown paths and MCP POST requests pass through unchanged", async () => {
+  await withFetch(
+    async (request) => {
+      assert.equal(request.url, `${ORIGIN}/~gitbook/mcp`);
+      assert.equal(request.method, "POST");
+      assert.equal(request.headers.get("authorization"), null);
+      assert.equal(request.headers.get("cookie"), null);
+      assert.equal(await request.text(), '{"jsonrpc":"2.0"}');
+      return new Response("upstream", {
+        status: 207,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+    async () => {
+      const response = await handleRequest(
+        new Request("https://preview.example/~gitbook/mcp", {
+          method: "POST",
+          headers: {
+            Authorization: "Bearer preview-only",
+            Cookie: "preview=1",
+            "Content-Type": "application/json",
+          },
+          body: '{"jsonrpc":"2.0"}',
+        }),
+      );
+      assert.equal(response.status, 207);
+      assert.equal(await response.text(), "upstream");
+    },
+  );
+});

--- a/cloudflare/docs-agent-discovery/wrangler.jsonc
+++ b/cloudflare/docs-agent-discovery/wrangler.jsonc
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://developers.cloudflare.com/schema/wrangler.json",
+  "name": "docs-thorchain-agent-discovery",
+  "main": "src/index.js",
+  "compatibility_date": "2026-08-26",
+  "workers_dev": false,
+  "preview_urls": true,
+  "routes": [
+    {
+      "pattern": "docs.thorchain.org",
+      "zone_name": "thorchain.org"
+    },
+    {
+      "pattern": "docs.thorchain.org/.well-known/*",
+      "zone_name": "thorchain.org"
+    },
+    {
+      "pattern": "docs.thorchain.org/auth.md",
+      "zone_name": "thorchain.org"
+    },
+    {
+      "pattern": "docs.thorchain.org/AGENTS.md",
+      "zone_name": "thorchain.org"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add truthful Auth.md, agent instructions, and a read-only documentation research skill
- add a narrowly routed Cloudflare Worker for RFC 8288 Link headers, RFC 9727 API catalog, MCP server card, Agent Skills index, and ARD manifest
- document the DNSSEC-validated DNS-AID SVCB record and rollback boundaries
- add the two human-readable agent pages to GitBook navigation

OAuth, A2A, WebMCP, registration, and payment metadata remain absent because this public documentation service does not provide those capabilities.

## Verification

- node test suite: 9 of 9 passed
- Cloudflare versioned Preview URL: public scanner Level 4, Agent-Integrated
- production scanner after rollout: Level 4, with Link headers, DNS-AID, API catalog, MCP card, Agent Skills, and ARD passing
- production homepage SHA-256 remained unchanged across the edge rollout
- HTML and Markdown negotiation remained available
- representative documentation routes and robots.txt remained available
- live GitBook MCP initialize still returns protocol 2025-06-18 and the verified tool capability
- published skill SHA-256 matches the served bytes
- Cloudflare and Google DNS resolvers return AD=true for the DNS-AID record

## Rollback

Remove only the four Worker routes declared in wrangler.jsonc and delete only the SVCB record declared in dns-aid-record.json. The GitBook CNAME is unchanged.