### PR TITLE
ecosystem: add EIDEX to Exchanges Only

### DIFF
--- a/ecosystem.md
+++ b/ecosystem.md
@@ -50,6 +50,8 @@ Below is a list of active THORChain community projects. If you would like to be 
 
 [**depouch**](https://depouch.com/) - Premier Cross-Chain DEX
 
+[**EIDEX**](https://eidex.io/screener) - Non-Custodial Route Screener Comparing 33+ Swap Sources
+
 [**FortunaSwap**](https://fortunaswap.finance/) - Cross-Chain DEX
 
 [**Jumper Exchange**](https://jumper.exchange/) - Multi-chain Liquidity Aggregator Powered by Li.Fi


### PR DESCRIPTION
Adds EIDEX to the Exchanges Only section, in alphabetical order between depouch and FortunaSwap. Single line, same format as the surrounding entries.

EIDEX is a non-custodial route screener: it compares live quotes from 33+ swap sources - DEX aggregators, bridges and instant exchangers - and ranks them by output amount. THORChain is one of those sources, so routes going through it are surfaced to users comparing their options.

EIDEX is already listed on thorchain.org/ecosystem.